### PR TITLE
Integrate Sysmon for Elastic v9.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ None.
   role_vars:
     ludus_elastic_enrollment_token: "<TOKEN>"
     ludus_elastic_fleet_server: "https://<IP>:8220" #8220 by default
-    ludus_elastic_agent_version: "8.12.2"
+    ludus_elastic_agent_version: "9.0.1"
 ```
 
 ## Example Ludus Range Config
@@ -90,7 +90,7 @@ ludus:
     roles:
       - badsectorlabs.ludus_elastic_agent
     role_vars:
-      ludus_elastic_agent_version: "8.12.6"
+      ludus_elastic_agent_version: "8.12.2"
       ludus_elastic_install_sysmon: false
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Available variables are listed below, along with default values (see `defaults/m
     # A valid agent version to download and install
     ludus_elastic_agent_version: ""
 
+    # Install Sysmon on any Windows host (Elastic v9.X ingests the log)
+    ludus_elastic_install_sysmon: false
+
+    # Sysmon install location
+    ludus_elastic_sysmon_path: "C:\\Program Files (x86)\\Sysmon"
+
 ## Dependencies
 
 None.
@@ -68,7 +74,26 @@ ludus:
     roles:
       - badsectorlabs.ludus_elastic_agent # role_vars are not required when using ludus
 ```
-
+Set the `role_vars` to install Elastic v9.X:
+```yaml
+ludus:
+  - vm_name: "{{ range_id }}-jumpbox01"
+    hostname: "{{ range_id }}-jumpbox01"
+    template: debian-12-x64-server-template
+    vlan: 20
+    ip_last_octet: 25
+    ram_gb: 4
+    cpus: 2
+    linux: true
+    testing:
+      snapshot: false
+      block_internet: false
+    roles:
+      - badsectorlabs.ludus_elastic_agent
+    role_vars:
+      ludus_elastic_agent_version: "9.0.1"
+      ludus_elastic_install_sysmon: true
+```
 ## Ludus setup
 
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Available variables are listed below, along with default values (see `defaults/m
     ludus_elastic_agent_version: ""
 
     # Install Sysmon on any Windows host (Elastic v9.X ingests the log)
-    ludus_elastic_install_sysmon: false
+    ludus_elastic_install_sysmon: ""
 
     # Sysmon install location
     ludus_elastic_sysmon_path: "C:\\Program Files (x86)\\Sysmon"
@@ -74,26 +74,26 @@ ludus:
     roles:
       - badsectorlabs.ludus_elastic_agent # role_vars are not required when using ludus
 ```
-Set the `role_vars` to install Elastic v9.X:
+
+Set the `role_vars` to install Elastic agent v8.X:
 ```yaml
 ludus:
   - vm_name: "{{ range_id }}-jumpbox01"
     hostname: "{{ range_id }}-jumpbox01"
-    template: debian-12-x64-server-template
+    template: win2022-server-x64-template
     vlan: 20
-    ip_last_octet: 25
-    ram_gb: 4
-    cpus: 2
-    linux: true
-    testing:
-      snapshot: false
-      block_internet: false
+    ip_last_octet: 21
+    ram_gb: 6
+    cpus: 4
+    windows:
+      sysprep: true
     roles:
       - badsectorlabs.ludus_elastic_agent
     role_vars:
-      ludus_elastic_agent_version: "9.0.1"
-      ludus_elastic_install_sysmon: true
+      ludus_elastic_agent_version: "8.12.6"
+      ludus_elastic_install_sysmon: false
 ```
+
 ## Ludus setup
 
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,6 @@ ludus_elastic_container_install_path: /opt/elastic_container # on the server VM 
 ludus_elastic_fleet_port: "8220" # what port does the server VM fleet service listen on (for automatic fleet server URL)
 ludus_elastic_enrollment_token: ""
 ludus_elastic_fleet_server: ""
-ludus_elastic_agent_version: "8.12.2"
-ludus_elastic_install_sysmon: false
+ludus_elastic_agent_version: "9.0.1"
+ludus_elastic_install_sysmon: ""
 ludus_elastic_sysmon_path: "C:\\Program Files (x86)\\Sysmon"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,5 @@ ludus_elastic_fleet_port: "8220" # what port does the server VM fleet service li
 ludus_elastic_enrollment_token: ""
 ludus_elastic_fleet_server: ""
 ludus_elastic_agent_version: "8.12.2"
+ludus_elastic_install_sysmon: false
+ludus_elastic_sysmon_path: "C:\\Program Files (x86)\\Sysmon"

--- a/tasks/sysmon.yml
+++ b/tasks/sysmon.yml
@@ -1,0 +1,70 @@
+- name: Get Elastic agents if needed
+  run_once: true
+  become: false
+  block:
+    - name: Create /opt/ludus/resources/sysmon directory if it doesn't exist
+      ansible.builtin.file:
+        path: "{{ ludus_install_directory }}/resources/sysmon"
+        state: directory
+        recurse: true
+      delegate_to: localhost
+
+    - name: Check if sysmon bin exists on Ludus for Windows targets
+      ansible.builtin.stat:
+        path: "{{ ludus_install_directory }}/resources/sysmon/sysmon.zip"
+      register: windows_sysmon_exists
+      delegate_to: localhost
+
+    - name: Download the Windows sysmon bin if it doesn't exist
+      ansible.builtin.get_url:
+        url: "https://download.sysinternals.com/files/Sysmon.zip"
+        dest: "{{ ludus_install_directory }}/resources/sysmon/sysmon.zip"
+        mode: "0644"
+      delegate_to: localhost
+      when: not windows_sysmon_exists.stat.exists
+
+    - name: Check if sysmon config exists on Ludus for Windows targets
+      ansible.builtin.stat:
+        path: "{{ ludus_install_directory }}/resources/sysmon/sysmon.xml"
+      register: windows_sysmon_config_exists
+      delegate_to: localhost
+
+    - name: Download the Windows sysmon config if it doesn't exist
+      ansible.builtin.get_url:
+        url: "https://github.com/SwiftOnSecurity/sysmon-config/raw/refs/heads/master/sysmonconfig-export.xml"
+        dest: "{{ ludus_install_directory }}/resources/sysmon/sysmon.xml"
+        mode: "0644"
+      delegate_to: localhost
+      when: not windows_sysmon_config_exists.stat.exists
+
+- name: Check if Sysmon is already installed
+  ansible.windows.win_service_info:
+    name: Sysmon
+  register: sysmon_service
+
+- name: Installing sysmon
+  when: not sysmon_service.exists
+  block:
+    - name: Create "{{ ludus_elastic_sysmon_path }}" directory if it doesn't exist
+      ansible.windows.win_file:
+        path: "{{ ludus_elastic_sysmon_path }}"
+        state: directory
+
+    - name: Copy Sysmon.zip to the target
+      ansible.windows.win_copy:
+        src: "{{ ludus_install_directory }}/resources/sysmon/sysmon.zip"
+        dest: "C:\\Ludus\\sysmon.zip"
+
+    - name: Copy Sysmon.xml to the target
+      ansible.windows.win_copy:
+        src: "{{ ludus_install_directory }}/resources/sysmon/sysmon.xml"
+        dest: "C:\\Program Files (x86)\\Sysmon\\sysmon.xml"
+
+    - name: Unzip Sysmon.zip
+      ansible.windows.win_powershell:
+        script: |
+          Expand-Archive -Path C:\Ludus\Sysmon.zip -DestinationPath "{{ ludus_elastic_sysmon_path }}"
+
+    - name: Install Sysmon
+      ansible.windows.win_shell: |
+        & "{{ ludus_elastic_sysmon_path }}\Sysmon.exe" -accepteula -i "{{ ludus_elastic_sysmon_path }}\Sysmon.xml"

--- a/tasks/sysmon.yml
+++ b/tasks/sysmon.yml
@@ -45,7 +45,7 @@
 - name: Installing sysmon
   when: not sysmon_service.exists
   block:
-    - name: Create "{{ ludus_elastic_sysmon_path }}" directory if it doesn't exist
+    - name: Create sysmon install directory if it doesn't exist
       ansible.windows.win_file:
         path: "{{ ludus_elastic_sysmon_path }}"
         state: directory

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -70,4 +70,9 @@
 - name: Installing Sysmon
   ansible.builtin.include_tasks:
     file: sysmon.yml
-  when: ludus_elastic_install_sysmon
+  when: |-
+    not ludus_elastic_install_sysmon == false 
+    and ( 
+      ludus_elastic_install_sysmon == true 
+      or ( ludus_elastic_install_sysmon == "" and ludus_elastic_agent_version is match("^[^1-8]\.") ) 
+    )

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -67,12 +67,21 @@
   ansible.windows.win_shell: |
     & "{{ elastic_agent_path }}" install --url="{{ elastic_url }}" --enrollment-token="{{ ludus_elastic_enrollment_token }}" --force --insecure
 
-- name: Installing Sysmon
-  ansible.builtin.include_tasks:
-    file: sysmon.yml
-  when: |-
-    not ludus_elastic_install_sysmon == false 
-    and ( 
-      ludus_elastic_install_sysmon == true 
-      or ( ludus_elastic_install_sysmon == "" and ludus_elastic_agent_version is match("^[^1-8]\.") ) 
-    )
+- name: Classify sysmon toggle state
+  ansible.builtin.set_fact:
+    sysmon_state: >-
+      {%- set v = ludus_elastic_install_sysmon | default("") | string -%}
+      {%- if v == "" -%}
+        empty
+      {%- elif v | bool -%}
+        true
+      {%- else -%}
+        false
+      {%- endif -%}
+
+- name: Going to install Sysmon
+  ansible.builtin.include_tasks: sysmon.yml
+  when: >
+    sysmon_state == "true"
+    or ( sysmon_state == "empty"
+          and (ludus_elastic_agent_version is version("9.0.0", ">=")) )

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -66,3 +66,8 @@
 - name: Install Elastic agent on Windows target
   ansible.windows.win_shell: |
     & "{{ elastic_agent_path }}" install --url="{{ elastic_url }}" --enrollment-token="{{ ludus_elastic_enrollment_token }}" --force --insecure
+
+- name: Installing Sysmon
+  ansible.builtin.include_tasks:
+    file: sysmon.yml
+  when: ludus_elastic_install_sysmon


### PR DESCRIPTION
Elastic v9.0.1 also ingests Sysmon logs by default. Machines that don't have Sysmon are reported as unhealthy. This PR introduces the following changes:
- Added `ludus_elastic_install_sysmon` role variable for installing & configuring Sysmon along side the agent

The role installs the popular Sysmon config by SwiftOnSecurity (https://github.com/SwiftOnSecurity/sysmon-config).

The role still installs the Elastic v8.X by default, but now also supports Elastic agent v9.0.1 with Sysmon