### PR TITLE
Bump version to 9.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ None.
     - badsectorlabs.ludus_elastic_agent
   role_vars:
     ludus_elastic_enrollment_token: "<TOKEN>"
-    ludus_elastic_fleet_server: "https://<IP>:8220" #8220 by default
-    ludus_elastic_agent_version: "9.3.1"
+    ludus_elastic_fleet_server: "https://<IP>:8220" # :8220 by default
+    ludus_elastic_agent_version: "9.4.2"
 ```
 
 ## Example Ludus Range Config

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,6 @@ ludus_elastic_container_install_path: /opt/elastic_container # on the server VM 
 ludus_elastic_fleet_port: "8220" # what port does the server VM fleet service listen on (for automatic fleet server URL)
 ludus_elastic_enrollment_token: ""
 ludus_elastic_fleet_server: ""
-ludus_elastic_agent_version: "9.3.1"
-ludus_elastic_install_sysmon: true # if not set, defaults to true if the Elastic agent version is 9.0.0 or higher, false otherwise
+ludus_elastic_agent_version: "9.4.2"
+ludus_elastic_install_sysmon: true # Default if Elastic agent version is 9+
 ludus_elastic_sysmon_path: "C:\\Program Files (x86)\\Sysmon"


### PR DESCRIPTION
Bump the default agent version to 9.4.2

Dependent on version bump in https://github.com/badsectorlabs/ludus_elastic_container/pull/12
